### PR TITLE
Update schema to match canonical formats updates

### DIFF
--- a/json/newspaper/contentitem.schema.json
+++ b/json/newspaper/contentitem.schema.json
@@ -48,6 +48,10 @@
       "type": "string",
       "pattern": "^[a-z]{2}$"
     },
+    "ro": {
+        "description": "Reading order index of the content item, for the table of contents view on the interface. If not defined, the CI number (after 'i' in the ID) should be used.",
+        "type": "integer"
+    },
     "ft": {
       "description": "the rebuilt fulltext",
       "type": "string"

--- a/json/newspaper/issue.schema.json
+++ b/json/newspaper/issue.schema.json
@@ -22,6 +22,14 @@
                     "m": {
                         "description": "Metadata about the content item.",
                         "$ref": "#/definitions/metadata"
+                    },
+                    "c": {
+                        "type": "array",
+                        "description": "Coordinates of image-region corresponding to the content-item depending on its type (if `tp == image`).",
+                        "minItems":4,
+                        "items": {
+                            "type": "integer"
+                        }
                     }
                 },
                 "required": ["m"]
@@ -73,6 +81,10 @@
           "type": "string",
           "description": "Access rights. Three possible situations are defined:\n1. open public: access without NDA, user could redistribute (as defined per Terms of Use)\n2. open private: access without an NDA, user cannot redistribute (private/academic use only)\n3. closed : accessible only upon signing an NDA, user cannot redistribute",
           "enum": ["open_public", "open_private", "closed"]
+        }, 
+        "iiif_manifest_uri": {
+            "type": "string",
+            "description": "URI for the issue's manifest in the IIIF Presentation API, if the corresponding IIIF server has one."
         }
     },
     "required": ["id", "cdt", "i", "pp", "ar"],
@@ -106,7 +118,11 @@
                 },
                 "iiif_link": {
                   "type": "string",
-                  "description": "IIIF image link, depending on content item type (if `tp == image`)"
+                  "description": "IIIF image link, depending on content item type (if `tp == image`). Should follow the format: '{scheme}://{server}/{prefix}/{identifier}/info.json'."
+                },
+                "ro": {
+                    "type": "integer",
+                    "description": "Reading order index of the content item, for the table of contents view on the interface. If not defined, the CI number (after 'i' in the ID) should be used."
                 }
             },
             "required": ["id","pp", "tp"]

--- a/json/newspaper/page.schema.json
+++ b/json/newspaper/page.schema.json
@@ -11,7 +11,11 @@
         },
         "iiif":{
           "type": "string",
-          "description": "URI of the IIIF Manifest of the newspaper page image."
+          "description": "URI of the IIIF Manifest of the newspaper page image. Deprecated in favor of `iiif_img_base_uri` which should be used whenever it's defined, kept for backwards compatibility."
+        },
+        "iiif_img_base_uri":{
+          "type": "string",
+          "description": "Base of the IIIF image URI of the newspaper page image. Should follow format `{scheme}://{server}/{prefix}/{identifier}` and not include any suffix."
         },
         "cc":{
             "type": "boolean",


### PR DESCRIPTION
Adding the properties to Issue, Page and rebuilt Content-item schemas as described in issue #25:

**Issue Canonical Schema**
- Optional string property `iiif_manifest_uri` with the URI to the IIIF presentation manifest of the issue 
    - only applicable in the case of BNF, BNF-EN, SWA, BCUL data currently.
- Optional array property `c` (coordinates) for content-items `i` (outside of medtadata `m`)
- Optional integer property `ro` (reading order) providing an ordering of content-items in case they are not properly ordered in the ToC view on the interface. (In particular sorting them according to pages). The CI's numbering (int following `i` in the canonical ID) is to be used when this property is not defined.

**Page Canonical Schema**
- Optional property `iiif_img_base_uri` with the base of the IIIF image URI for the newspaper page image (without any suffix or coordinates).
- Mention of `iiif` as deprecated and to be replaced by `iiif_img_base_uri` in all newly ingested data.

**Rebuilt Content-Item Schema**
- Optional integer property `ro` (reading order) providing an ordering of content-items in case they are not properly ordered in the ToC view on the interface. (In particular sorting them according to pages). The CI's numbering (int following `i` in the canonical ID) is to be used when this property is not defined.

These changes are related to Issues [#117](https://github.com/impresso/impresso-text-acquisition/issues/117) and [#74](https://github.com/impresso/impresso-text-acquisition/issues/74) of the [Canonical Text-importer package](https://github.com/impresso/impresso-text-acquisition).
Solves #25.